### PR TITLE
Easy LiveGrid fix

### DIFF
--- a/startup/80-areadetectors.py
+++ b/startup/80-areadetectors.py
@@ -311,6 +311,8 @@ class SrxXspress3Detector(SRXXspressTrigger, Xspress3Detector):
 
     erase = Cpt(EpicsSignal, 'ERASE')
 
+    array_counter = Cpt(EpicsSignal, 'ArrayCounter_RBV')
+
     # Currently only using three channels. Uncomment these to enable more
     channel1 = C(Xspress3Channel, 'C1_', channel_num=1, read_attrs=['rois'])
     channel2 = C(Xspress3Channel, 'C2_', channel_num=2, read_attrs=['rois'])

--- a/startup/91-flyscans.py
+++ b/startup/91-flyscans.py
@@ -810,10 +810,8 @@ def scan_and_fly_base(detectors, xstart, xstop, xnum, ystart, ystop, ynum, dwell
 
         def event(self, doc):
             if self.I in doc['data']:
-                print(f'found {self.I}')
                 self._previous_roi = doc['data'][self.I]
             elif self._array_counter_key in doc['data']:
-                print(f'found {self._array_counter_key}')
                 doc = doc.copy()
                 doc['data'][self.I] = self._previous_roi
             else:
@@ -833,7 +831,7 @@ def scan_and_fly_base(detectors, xstart, xstop, xnum, ystart, ystop, ynum, dwell
         livepopup = ArrayCounterLiveGrid(
             (ynum, xnum + 1),
             xs.channel1.rois.roi01.value.name,
-            array_counter_key=xs.array_counter.name,  # 'XF:05IDD-ES{Xsp:1}:ArrayCounter_RBV',
+            array_counter_key=xs.array_counter.name,
             extent=(xstart, xstop, ystart, ystop),
             x_positive='right', y_positive='down'
         )
@@ -842,7 +840,6 @@ def scan_and_fly_base(detectors, xstart, xstop, xnum, ystart, ystop, ynum, dwell
     @subs_decorator({'start': at_scan})
     @subs_decorator({'stop': finalize_scan})
     # monitor values from xs
-    # @monitor_during_decorator([xs.channel1.rois.roi01.value])
     @monitor_during_decorator([xs.channel1.rois.roi01.value, xs.array_counter])
     @stage_decorator([flying_zebra])  # Below, 'scan' stage ymotor.
     @run_decorator(md=md)

--- a/startup/91-flyscans.py
+++ b/startup/91-flyscans.py
@@ -833,7 +833,7 @@ def scan_and_fly_base(detectors, xstart, xstop, xnum, ystart, ystop, ynum, dwell
         livepopup = ArrayCounterLiveGrid(
             (ynum, xnum + 1),
             xs.channel1.rois.roi01.value.name,
-            array_counter_key='XF:05IDD-ES{Xsp:1}:ArrayCounter_RBV',
+            array_counter_key=xs.array_counter.name,  # 'XF:05IDD-ES{Xsp:1}:ArrayCounter_RBV',
             extent=(xstart, xstop, ystart, ystop),
             x_positive='right', y_positive='down'
         )
@@ -843,7 +843,7 @@ def scan_and_fly_base(detectors, xstart, xstop, xnum, ystart, ystop, ynum, dwell
     @subs_decorator({'stop': finalize_scan})
     # monitor values from xs
     # @monitor_during_decorator([xs.channel1.rois.roi01.value])
-    @monitor_during_decorator([xs.channel1.rois.roi01.value, 'XF:05IDD-ES{Xsp:1}:ArrayCounter_RBV'])
+    @monitor_during_decorator([xs.channel1.rois.roi01.value, xs.array_counter])
     @stage_decorator([flying_zebra])  # Below, 'scan' stage ymotor.
     @run_decorator(md=md)
     def plan():
@@ -886,6 +886,7 @@ def scan_and_fly_base(detectors, xstart, xstop, xnum, ystart, ystop, ynum, dwell
         # toc(t_open, str='Open shutter')
 
     # Run the scan
+    yield from mv(xs.erase, 0)
     uid = yield from final_plan
 
     # Close the shutter


### PR DESCRIPTION
This PR proposes a fix for the case of 'missing' PV monitor updates to LiveGrid.

This fix monitors the 'ArrayCounter_RBV' PV in addition to the ROI PV. The new PV monitor updates on every new acquisition, while the ROI PV monitor updates only if it changes. A new class ArrayCounterLiveGrid is defined that responds to 'ArrayCounter_RBV' updates by plotting the previous ROI value.

A new EpicsSignal has been added to the Xspress3 class for the 'ArrayCounter_RBV' PV.

This fix has been tested at SRX without beam.