### PR TITLE
Migrate databroker handlers

### DIFF
--- a/startup/22-dexela.py
+++ b/startup/22-dexela.py
@@ -1,7 +1,6 @@
 import os
 import ophyd
 from hxntools.detectors.dexela import (DexelaDetector,)
-from databroker.assets.handlers import HandlerBase
 from ophyd.areadetector.filestore_mixins import (FileStoreIterativeWrite,
                                                  FileStoreHDF5IterativeWrite,
                                                  FileStoreTIFFSquashing,
@@ -38,22 +37,12 @@ def _ensure_trailing_slash(path):
 
 ophyd.areadetector.filestore_mixins._ensure_trailing_slash = _ensure_trailing_slash
 
-class BulkDexela(HandlerBase):
-    HANDLER_NAME = 'DEXELA_FLY_V1'
-    def __init__(self, resource_fn):
-        self._handle = h5py.File(resource_fn, 'r')
-
-    def __call__(self):
-        return self._handle['entry/instrument/detector/data'][:]
-
-db.reg.register_handler(BulkDexela.HANDLER_NAME, BulkDexela,
-                        overwrite=True)
 
 class DexelaFileStoreHDF5(FileStoreBase):
     @property
     def filestore_spec(self):
         if self.parent._mode is SRXMode.fly:
-            return BulkDexela.HANDLER_NAME
+            return 'DEXELA_FLY_V1'
         return 'TPX_HDF5'
 
     def __init__(self, *args, **kwargs):

--- a/startup/80-areadetectors.py
+++ b/startup/80-areadetectors.py
@@ -168,39 +168,7 @@ from pathlib import PurePath
 from hxntools.detectors.xspress3 import (XspressTrigger, Xspress3Detector,
                                          Xspress3Channel, Xspress3FileStore,
                                          logger)
-from databroker.assets.handlers import Xspress3HDF5Handler, HandlerBase
 
-
-class BulkXSPRESS(HandlerBase):
-    HANDLER_NAME = 'XPS3_FLY'
-    def __init__(self, resource_fn):
-        self._handle = h5py.File(resource_fn, 'r')
-
-    def __call__(self):
-        return self._handle['entry/instrument/detector/data'][:]
-
-
-class BulkMerlin(BulkXSPRESS):
-    HANDLER_NAME = 'MERLIN_FLY_STREAM_V1'
-    def __call__(self):
-        return self._handle['entry/instrument/detector/data'][:]
-
-
-class BulkMerlinDEBUG(BulkXSPRESS):
-    # This is for data take in 'capture' mode, only used for debugging
-    # once.
-    HANDLER_NAME = 'MERLIN_FLY'
-    def __call__(self):
-        return self._handle['entry/instrument/detector/data'][1:]
-
-
-db.reg.register_handler(BulkXSPRESS.HANDLER_NAME, BulkXSPRESS,
-                        overwrite=True)
-# needed to get at some debugging data
-db.reg.register_handler('MERLIN_FLY', BulkMerlinDEBUG,
-                        overwrite=True)
-db.reg.register_handler(BulkMerlin.HANDLER_NAME, BulkMerlin,
-                        overwrite=True)
 
 from ophyd.areadetector.filestore_mixins import FileStorePluginBase
 class Xspress3FileStoreFlyable(Xspress3FileStore):
@@ -215,8 +183,8 @@ class Xspress3FileStoreFlyable(Xspress3FileStore):
     @property
     def filestore_spec(self):
         if self.parent._mode is SRXMode.fly:
-           return BulkXSPRESS.HANDLER_NAME
-        return Xspress3HDF5Handler.HANDLER_NAME
+           return 'XPS3_FLY'
+        return 'XSP3'
 
     def generate_datum(self, key, timestamp, datum_kwargs):
         if self.parent._mode is SRXMode.step:
@@ -535,7 +503,7 @@ class MerlinFileStoreHDF5(FileStoreBase):
     @property
     def filestore_spec(self):
         if self.parent._mode is SRXMode.fly:
-            return BulkMerlin.HANDLER_NAME
+            return 'MERLIN_FLY_STREAM_V1'
         return 'TPX_HDF5'
 
     def generate_datum(self, key, timestamp, datum_kwargs):

--- a/startup/91-flyscans.py
+++ b/startup/91-flyscans.py
@@ -911,17 +911,6 @@ class RowBasedLiveGrid(LiveGrid):
         self._pad = None
 
 
-class SrxXSP3Handler:
-    XRF_DATA_KEY = 'entry/instrument/detector/data'
-
-    def __init__(self, filepath, **kwargs):
-        self._filepath = filepath
-
-    def __call__(self, **kwargs):
-        with h5py.File(self._filepath, 'r') as f:
-            return np.asarray(f[self.XRF_DATA_KEY])
-
-
 def batch_fly(paramlist, kwlist=None, zlist=None):
     '''
     paramlist   list    list of positional and dwell time arguments to scan_and_fly

--- a/startup/91-flyscans.py
+++ b/startup/91-flyscans.py
@@ -471,26 +471,6 @@ def export_sis_data(ion, filepath):
         dset3[...] = np.array(new_it)
         f.close()
 
-class ZebraHDF5Handler(HandlerBase):
-    HANDLER_NAME = 'ZEBRA_HDF51'
-    def __init__(self, resource_fn):
-        self._handle = h5py.File(resource_fn, 'r')
-
-    def __call__(self, *, column):
-        return self._handle[column][:]
-
-class SISHDF5Handler(HandlerBase):
-    HANDLER_NAME = 'SIS_HDF51'
-    def __init__(self, resource_fn):
-        self._handle = h5py.File(resource_fn, 'r')
-
-    def __call__(self, *, column):
-        return self._handle[column][:]
-
-
-db.reg.register_handler('SIS_HDF51', SISHDF5Handler, overwrite=True)
-db.reg.register_handler('ZEBRA_HDF51', ZebraHDF5Handler, overwrite=True)
-
 
 class LiveZebraPlot(CallbackBase):
     """


### PR DESCRIPTION
Databroker handlers will be migrated to dedicated repositories as part of April deployment.

Related: https://github.com/bluesky/databroker/issues/533

Handlers will be moved to [area-detector-handlers](https://github.com/bluesky/area-detector-handlers) and [nsls2-detector-handlers](https://github.com/bluesky/nsls2-detector-handlers).