### PR TITLE
Fix CI builds/tests

### DIFF
--- a/.ci/bl-specific.sh
+++ b/.ci/bl-specific.sh
@@ -7,6 +7,7 @@ sudo mkdir -v -p /nsls2/xf05id1/shared/config/ \
                  /nsls2/xf05id1/experiments/ \
                  /nsls2/xf05id1/shared/src/bluesky_scripts/
 
+sudo chmod -Rv go+rw /nsls2/xf05id1/
+
 touch /nsls2/xf05id1/shared/src/bluesky_scripts/simple_batch.py
 
-sudo chmod -Rv go+rw /nsls2/xf05id1/

--- a/.ci/bl-specific.sh
+++ b/.ci/bl-specific.sh
@@ -2,3 +2,6 @@
 
 # The beamline-specific metapackages are not used since 2020-2.0 deployment.
 # conda install -y -c ${CONDA_CHANNEL_NAME} <package>
+
+sudo mkdir -v -p /nsls2/xf05id1/shared/config/
+sudo chmod -v 777 /nsls2/xf05id1/shared/config/

--- a/.ci/bl-specific.sh
+++ b/.ci/bl-specific.sh
@@ -3,5 +3,5 @@
 # The beamline-specific metapackages are not used since 2020-2.0 deployment.
 # conda install -y -c ${CONDA_CHANNEL_NAME} <package>
 
-sudo mkdir -v -p /nsls2/xf05id1/shared/config/
-sudo chmod -v 777 /nsls2/xf05id1/shared/config/
+sudo mkdir -v -p /nsls2/xf05id1/shared/config/ /nsls2/xf05id1/experiments/
+sudo chmod -Rv 777 /nsls2/xf05id1/

--- a/.ci/bl-specific.sh
+++ b/.ci/bl-specific.sh
@@ -3,5 +3,10 @@
 # The beamline-specific metapackages are not used since 2020-2.0 deployment.
 # conda install -y -c ${CONDA_CHANNEL_NAME} <package>
 
-sudo mkdir -v -p /nsls2/xf05id1/shared/config/ /nsls2/xf05id1/experiments/
-sudo chmod -Rv 777 /nsls2/xf05id1/
+sudo mkdir -v -p /nsls2/xf05id1/shared/config/ \
+                 /nsls2/xf05id1/experiments/ \
+                 /nsls2/xf05id1/shared/src/bluesky_scripts/
+
+touch /nsls2/xf05id1/shared/src/bluesky_scripts/simple_batch.py
+
+sudo chmod -Rv go+rw /nsls2/xf05id1/

--- a/.ci/bl-specific.sh
+++ b/.ci/bl-specific.sh
@@ -10,4 +10,4 @@ sudo mkdir -v -p /nsls2/xf05id1/shared/config/ \
 sudo chmod -Rv go+rw /nsls2/xf05id1/
 
 touch /nsls2/xf05id1/shared/src/bluesky_scripts/simple_batch.py
-
+touch /nsls2/xf05id1/shared/src/bluesky_scripts/fly_batch.py

--- a/startup/90-usersetup.py
+++ b/startup/90-usersetup.py
@@ -32,8 +32,9 @@ RE.md['proposal']  = {'proposal_num': str(proposal_num),
                       'saf_num': str(saf_num),
                       'cycle': str(cycle)}
 
-# Set user data in scanbroker
-scanrecord.update_metadata()
+if 'TOUCHBEAMLINE' in os.environ and os.environ['TOUCHBEAMLINE'] == 1:
+    # Set user data in scanbroker
+    scanrecord.update_metadata()
 
 # User data directory and simple scripts
 userdatadir = '/nsls2/xf05id1/experiments/' + str(cycle) + '/' + str(saf_num) + '_' + str(PI_lastname) + '/'


### PR DESCRIPTION
Summary:
- add beamline-specific steps to create `/nsls2/xf05id1/*` dirs and set appropriate permissions
- create expected `.py` files in `/nsls2/xf05id1/*`
- update `scanrecord` only when the environment variable `TOUCHBEAMLINE=1`