### PR TITLE
Fix the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020, Brookhaven Science Associates, Brookhaven National Laboratory
+Copyright (c) 2020, Brookhaven National Laboratory
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The copyright holder should be "Brookhaven National Laboratory". See https://github.com/NSLS-II/scientific-python-cookiecutter/issues/89#issuecomment-591649337.