### PR TITLE
Reduced number of ROIs to read on XS3

### DIFF
--- a/startup/31-xspress3.py
+++ b/startup/31-xspress3.py
@@ -262,20 +262,21 @@ class SrxXspress3Detector(SRXXspressTrigger, Xspress3Detector):
 
 try:
     xs = SrxXspress3Detector("XF:05IDD-ES{Xsp:1}:", name="xs")
-    if "TOUCHBEAMLINE" in os.environ and os.environ["TOUCHBEAMLINE"] == 1:
-        xs.channel1.rois.read_attrs = ["roi{:02}".format(j)
-                                       for j in [1, 2, 3, 4]]
-        xs.channel2.rois.read_attrs = ["roi{:02}".format(j)
-                                       for j in [1, 2, 3, 4]]
-        xs.channel3.rois.read_attrs = ["roi{:02}".format(j)
-                                       for j in [1, 2, 3, 4]]
-        xs.channel4.rois.read_attrs = ["roi{:02}".format(j)
-                                       for j in [1, 2, 3, 4]]
-        xs.hdf5.num_extra_dims.put(0)
+    xs.channel1.rois.read_attrs = ["roi{:02}".format(j)
+                                   for j in [1, 2, 3, 4]]
+    xs.channel2.rois.read_attrs = ["roi{:02}".format(j)
+                                   for j in [1, 2, 3, 4]]
+    xs.channel3.rois.read_attrs = ["roi{:02}".format(j)
+                                   for j in [1, 2, 3, 4]]
+    xs.channel4.rois.read_attrs = ["roi{:02}".format(j)
+                                   for j in [1, 2, 3, 4]]
+    if "TOUCHBEAMLINE" in os.environ and os.environ["TOUCHBEAMLINE"] == '1':
+        xs.settings.num_channels.put(4) #4 for ME4 detector
+        xs.channel1.vis_enabled.put(1)
         xs.channel2.vis_enabled.put(1)
         xs.channel3.vis_enabled.put(1)
         xs.channel4.vis_enabled.put(1)
-        xs.settings.num_channels.put(4) #4 for ME4 detector
+        xs.hdf5.num_extra_dims.put(0)
 
         xs.settings.configuration_attrs = [
             "acquire_period",
@@ -413,9 +414,9 @@ try:
     xs2 = SrxXspress3Detector2("XF:05IDD-ES{Xsp:2}:",
                                name="xs2",
                                f_key="fluor_xs2")
-    if "TOUCHBEAMLINE" in os.environ and os.environ["TOUCHBEAMLINE"] == 1:
-        xs2.channel1.rois.read_attrs = ["roi{:02}".format(j)
-                                        for j in [1, 2, 3, 4]]
+    xs2.channel1.rois.read_attrs = ["roi{:02}".format(j)
+                                    for j in [1, 2, 3, 4]]
+    if "TOUCHBEAMLINE" in os.environ and os.environ["TOUCHBEAMLINE"] == '1':
         xs2.hdf5.num_extra_dims.put(0)
         xs2.hdf5.warmup()
 except TimeoutError:

--- a/startup/31-xspress3.py
+++ b/startup/31-xspress3.py
@@ -270,7 +270,7 @@ try:
                                    for j in [1, 2, 3, 4]]
     xs.channel4.rois.read_attrs = ["roi{:02}".format(j)
                                    for j in [1, 2, 3, 4]]
-    if "TOUCHBEAMLINE" in os.environ and os.environ["TOUCHBEAMLINE"] == '1':
+    if os.getenv("TOUCHBEAMLINE", "0") == "1":
         xs.settings.num_channels.put(4) #4 for ME4 detector
         xs.channel1.vis_enabled.put(1)
         xs.channel2.vis_enabled.put(1)
@@ -416,7 +416,7 @@ try:
                                f_key="fluor_xs2")
     xs2.channel1.rois.read_attrs = ["roi{:02}".format(j)
                                     for j in [1, 2, 3, 4]]
-    if "TOUCHBEAMLINE" in os.environ and os.environ["TOUCHBEAMLINE"] == '1':
+    if os.getenv("TOUCHBEAMLINE", "0") == "1":
         xs2.hdf5.num_extra_dims.put(0)
         xs2.hdf5.warmup()
 except TimeoutError:

--- a/startup/90-usersetup.py
+++ b/startup/90-usersetup.py
@@ -28,7 +28,7 @@ saf_num = 305921
 # saf_num = 306149
 
 
-cycle = '2020_cycle3'
+cycle = '2021_cycle1'
 
 # Set user data in bluesky
 RE.md['proposal']  = {'proposal_num': str(proposal_num),


### PR DESCRIPTION
Committed and pushed by @andrewmkiss. See https://github.com/NSLS-II-SRX/profile_collection/issues/18#issuecomment-767063118.

> Changed read_attrs to only read first 4 ROIs on xs3
> This was previously only applied if TOUCHBEAMLINE == 1
> 
> Also, TOUCHBEAMLINE is a string so changed to == '1'
> 
> Updated operating cycle