### PR TITLE
IPython "WARNING" log level

### DIFF
--- a/startup/00-base.py
+++ b/startup/00-base.py
@@ -53,10 +53,10 @@ class SRXPrompt(Prompts):
             (Token.Prompt, "]: "),
         ]
 
-
 ip = get_ipython()
 nslsii.configure_base(ip.user_ns, "srx")
 ip.log.setLevel('WARNING')
+
 nslsii.configure_olog(ip.user_ns)
 ip.prompts = SRXPrompt(ip)
 


### PR DESCRIPTION
An alternative fix/workaround of https://github.com/NSLS-II/nslsii/issues/115. I tested it, and now it does not print the `[TerminalIPythonApp]` messages to the screen. It would be still nice to have it configurable in `nslsii`. 