### PR TITLE
Migrate databroker handlers fixed

### DIFF
--- a/startup/30-scaler.py
+++ b/startup/30-scaler.py
@@ -7,7 +7,6 @@ from ophyd import Device, EpicsScaler, EpicsSignal, EpicsSignalRO
 from ophyd import Component as Cpt
 from ophyd.device import DynamicDeviceComponent as DDC
 from collections import OrderedDict
-from databroker.assets.handlers import HandlerBase
 
 
 class EpicsSignalROLazyier(EpicsSignalRO):
@@ -129,15 +128,3 @@ def export_sis_data(ion, filepath, zebra):
         dset3[...] = np.array(new_it)
         f.close()
 
-
-class SISHDF5Handler(HandlerBase):
-    HANDLER_NAME = "SIS_HDF51"
-
-    def __init__(self, resource_fn):
-        self._handle = h5py.File(resource_fn, "r")
-
-    def __call__(self, *, column):
-        return self._handle[column][:]
-
-
-db.reg.register_handler("SIS_HDF51", SISHDF5Handler, overwrite=True)

--- a/startup/31-xspress3.py
+++ b/startup/31-xspress3.py
@@ -148,17 +148,6 @@ class SRXXspressTrigger(XspressTrigger):
         return self._status
 
 
-class SrxXSP3Handler:
-    XRF_DATA_KEY = "entry/instrument/detector/data"
-
-    def __init__(self, filepath, **kwargs):
-        self._filepath = filepath
-
-    def __call__(self, **kwargs):
-        with h5py.File(self._filepath, "r") as f:
-            return np.asarray(f[self.XRF_DATA_KEY])
-
-
 class SrxXspress3Detector(SRXXspressTrigger, Xspress3Detector):
     # TODO: garth, the ioc is missing some PVs?
     #   det_settings.erase_array_counters

--- a/startup/31-xspress3.py
+++ b/startup/31-xspress3.py
@@ -19,29 +19,10 @@ from nslsii.detectors.xspress3 import (
     Xspress3FileStore,
 )
 
-try:
-    from area_detector_handlers import HandlerBase
-    from area_detector_handlers.handlers import Xspress3HDF5Handler
-except ImportError:
-    from databroker.assets.handlers import Xspress3HDF5Handler, HandlerBase
-
 
 class SRXMode(Enum):
     step = 1
     fly = 2
-
-
-class BulkXspress(HandlerBase):
-    HANDLER_NAME = "XPS3_FLY"
-
-    def __init__(self, resource_fn):
-        self._handle = h5py.File(resource_fn, "r")
-
-    def __call__(self):
-        return self._handle["entry/instrument/detector/data"][:]
-
-
-db.reg.register_handler(BulkXspress.HANDLER_NAME, BulkXspress, overwrite=True)
 
 
 class Xspress3FileStoreFlyable(Xspress3FileStore):
@@ -56,8 +37,8 @@ class Xspress3FileStoreFlyable(Xspress3FileStore):
     @property
     def filestore_spec(self):
         if self.parent._mode is SRXMode.fly:
-            return BulkXspress.HANDLER_NAME
-        return Xspress3HDF5Handler.HANDLER_NAME
+            return 'XPS3_FLY'
+        return 'XSP3'
 
     def generate_datum(self, key, timestamp, datum_kwargs):
         if self.parent._mode is SRXMode.step:

--- a/startup/32-zebra.py
+++ b/startup/32-zebra.py
@@ -748,15 +748,3 @@ def export_zebra_data(zebra, filepath, fast_axis):
         dset3 = f.create_dataset("enc3", size, dtype="f")
         dset3[...] = np.array(enc3_d)
 
-
-class ZebraHDF5Handler(HandlerBase):
-    HANDLER_NAME = "ZEBRA_HDF51"
-
-    def __init__(self, resource_fn):
-        self._handle = h5py.File(resource_fn, "r")
-
-    def __call__(self, *, column):
-        return self._handle[column][:]
-
-
-db.reg.register_handler("ZEBRA_HDF51", ZebraHDF5Handler, overwrite=True)

--- a/startup/34-merlin.py
+++ b/startup/34-merlin.py
@@ -31,27 +31,6 @@ from hxntools.detectors.merlin import MerlinDetector
 from hxntools.handlers import register
 
 
-class BulkMerlin(BulkXspress):
-    HANDLER_NAME = 'MERLIN_FLY_STREAM_V1'
-    def __call__(self):
-        return self._handle['entry/instrument/detector/data'][:]
-
-
-class BulkMerlinDebug(BulkXspress):
-    # This is for data take in 'capture' mode, only used for debugging
-    # once.
-    HANDLER_NAME = 'MERLIN_FLY'
-    def __call__(self):
-        return self._handle['entry/instrument/detector/data'][1:]
-
-
-# needed to get at some debugging data
-db.reg.register_handler('MERLIN_FLY', BulkMerlinDebug,
-                        overwrite=True)
-db.reg.register_handler(BulkMerlin.HANDLER_NAME, BulkMerlin,
-                        overwrite=True)
-
-
 class MerlinFileStoreHDF5(FileStoreBase):
 
     _spec = 'TPX_HDF5'
@@ -85,7 +64,7 @@ class MerlinFileStoreHDF5(FileStoreBase):
     @property
     def filestore_spec(self):
         if self.parent._mode is SRXMode.fly:
-            return BulkMerlin.HANDLER_NAME
+            return 'MERLIN_FLY_STREAM_V1'
         return 'TPX_HDF5'
 
     def generate_datum(self, key, timestamp, datum_kwargs):

--- a/startup/35-dexela.py
+++ b/startup/35-dexela.py
@@ -8,7 +8,6 @@ import datetime
 import ophyd
 from hxntools.detectors.dexela import (DexelaDetector,)
 from nslsii.detectors.xspress3 import (logger, )
-from databroker.assets.handlers import HandlerBase
 from ophyd.areadetector.filestore_mixins import (FileStoreIterativeWrite,
                                                  FileStoreHDF5IterativeWrite,
                                                  FileStoreTIFFSquashing,
@@ -25,25 +24,11 @@ from ophyd.areadetector import (AreaDetector, PixiradDetectorCam, ImagePlugin,
 from ophyd import Component as Cpt
 
 
-class BulkDexela(HandlerBase):
-    HANDLER_NAME = 'DEXELA_FLY_V1'
-
-    def __init__(self, resource_fn):
-        self._handle = h5py.File(resource_fn, 'r')
-
-    def __call__(self):
-        return self._handle['entry/instrument/detector/data'][:]
-
-
-db.reg.register_handler(BulkDexela.HANDLER_NAME, BulkDexela,
-                        overwrite=True)
-
-
 class DexelaFileStoreHDF5(FileStoreBase):
     @property
     def filestore_spec(self):
         if self.parent._mode is SRXMode.fly:
-            return BulkDexela.HANDLER_NAME
+            return 'DEXELA_FLY_V1'
         return 'TPX_HDF5'
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Updated version of #9.

Databroker handlers are being migrated to dedicated repositories.

Related: https://github.com/bluesky/databroker/issues/533

Handlers moved to [area-detector-handlers](https://github.com/bluesky/area-detector-handlers) and [nsls2-detector-handlers](https://github.com/bluesky/nsls2-detector-handlers).