### PR TITLE
xspress3 support with the community IOC

### DIFF
--- a/startup/31-community-ioc-base-xspress3.py
+++ b/startup/31-community-ioc-base-xspress3.py
@@ -325,4 +325,3 @@ class CommunityXspressTrigger(BlueskyInterface):
 
         self._abs_trigger_count += 1
         return self._status
-

--- a/startup/31-xspress3.py
+++ b/startup/31-xspress3.py
@@ -15,12 +15,20 @@ from ophyd.device import Staged
 from enum import Enum
 from collections import deque, OrderedDict
 
-from nslsii.detectors.xspress3 import (
-    XspressTrigger,
-    Xspress3Detector,
-    Xspress3Channel,
-    Xspress3FileStore,  #  JL use CommunityXspress3FileStore
+from ophyd.areadetector import Xspress3Detector
+from nslsii.areadetector.xspress3 import (
+    build_xspress3_class,
+    Xspress3HDF5Plugin,
+    Xspress3Trigger
 )
+
+
+# from nslsii.detectors.xspress3 import (
+#     XspressTrigger,
+#     Xspress3Detector,
+#     Xspress3Channel,
+#     Xspress3FileStore,  #  JL use CommunityXspress3FileStore
+# )
 
 # this is the community IOC package
 from nslsii.areadetector.xspress3 import (
@@ -69,90 +77,90 @@ class BulkXspress(HandlerBase):
 db.reg.register_handler(BulkXspress.HANDLER_NAME, BulkXspress, overwrite=True)
 
 
-class Xspress3FileStoreFlyable(Xspress3FileStore):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+# class Xspress3FileStoreFlyable(Xspress3FileStore):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
 
-    @property
-    def filestore_res(self):
-        raise Exception("don't want to be here")
-        return self._filestore_res
+#     @property
+#     def filestore_res(self):
+#         raise Exception("don't want to be here")
+#         return self._filestore_res
 
-    @property
-    def filestore_spec(self):
-        if self.parent._mode is SRXMode.fly:
-            return BulkXspress.HANDLER_NAME
-        return Xspress3HDF5Handler.HANDLER_NAME
+#     @property
+#     def filestore_spec(self):
+#         if self.parent._mode is SRXMode.fly:
+#             return BulkXspress.HANDLER_NAME
+#         return Xspress3HDF5Handler.HANDLER_NAME
 
-    def generate_datum(self, key, timestamp, datum_kwargs):
-        if self.parent._mode is SRXMode.step:
-            return super().generate_datum(key, timestamp, datum_kwargs)
-        elif self.parent._mode is SRXMode.fly:
-            # we are doing something _very_ dirty here to skip a level
-            # of the inheritance
-            # this is brittle is if the MRO changes we may not hit all
-            # the level we expect to
-            return FileStorePluginBase.generate_datum(
-                self, key, timestamp, datum_kwargs
-            )
+#     def generate_datum(self, key, timestamp, datum_kwargs):
+#         if self.parent._mode is SRXMode.step:
+#             return super().generate_datum(key, timestamp, datum_kwargs)
+#         elif self.parent._mode is SRXMode.fly:
+#             # we are doing something _very_ dirty here to skip a level
+#             # of the inheritance
+#             # this is brittle is if the MRO changes we may not hit all
+#             # the level we expect to
+#             return FileStorePluginBase.generate_datum(
+#                 self, key, timestamp, datum_kwargs
+#             )
 
-    def warmup(self):
-        """
-        A convenience method for 'priming' the plugin.
-        The plugin has to 'see' one acquisition before it is ready to capture.
-        This sets the array size, etc.
+#     def warmup(self):
+#         """
+#         A convenience method for 'priming' the plugin.
+#         The plugin has to 'see' one acquisition before it is ready to capture.
+#         This sets the array size, etc.
 
-        NOTE : this comes from:
-            https://github.com/NSLS-II/ophyd/blob/master/ophyd/areadetector/plugins.py
-        We had to replace "settings" with "settings" here.
-        Also modified the stage sigs.
+#         NOTE : this comes from:
+#             https://github.com/NSLS-II/ophyd/blob/master/ophyd/areadetector/plugins.py
+#         We had to replace "settings" with "settings" here.
+#         Also modified the stage sigs.
 
-        """
-        print("  Warming up the hdf5 plugin...", end="", flush=True)
-        # set_and_wait(self.enable, 1)  // deprecated
-        self.enable.set(1).wait()
-        sigs = OrderedDict(
-            [
-                (self.parent.settings.array_callbacks, 1),
-                (self.parent.settings.image_mode, "Single"),
-                (self.parent.settings.trigger_mode, "Internal"),
-                # In case the acquisition time is set very long
-                (self.parent.settings.acquire_time, 1),
-                # (self.parent.settings.acquire_period, 1),
-                (self.parent.settings.acquire, 1),
-            ]
-        )
+#         """
+#         print("  Warming up the hdf5 plugin...", end="", flush=True)
+#         # set_and_wait(self.enable, 1)  // deprecated
+#         self.enable.set(1).wait()
+#         sigs = OrderedDict(
+#             [
+#                 (self.parent.settings.array_callbacks, 1),
+#                 (self.parent.settings.image_mode, "Single"),
+#                 (self.parent.settings.trigger_mode, "Internal"),
+#                 # In case the acquisition time is set very long
+#                 (self.parent.settings.acquire_time, 1),
+#                 # (self.parent.settings.acquire_period, 1),
+#                 (self.parent.settings.acquire, 1),
+#             ]
+#         )
 
-        original_vals = {sig: sig.get() for sig in sigs}
+#         original_vals = {sig: sig.get() for sig in sigs}
 
-        for sig, val in sigs.items():
-            ttime.sleep(0.1)  # abundance of caution
-            # set_and_wait(sig, val)  // deprecated
-            sig.set(val).wait()
+#         for sig, val in sigs.items():
+#             ttime.sleep(0.1)  # abundance of caution
+#             # set_and_wait(sig, val)  // deprecated
+#             sig.set(val).wait()
 
-        ttime.sleep(2)  # wait for acquisition
+#         ttime.sleep(2)  # wait for acquisition
 
-        for sig, val in reversed(list(original_vals.items())):
-            ttime.sleep(0.1)
-            # set_and_wait(sig, val)  // deprecated
-            sig.set(val).wait()
-        print("done")
+#         for sig, val in reversed(list(original_vals.items())):
+#             ttime.sleep(0.1)
+#             # set_and_wait(sig, val)  // deprecated
+#             sig.set(val).wait()
+#         print("done")
 
-    def describe(self):
-        desc = super().describe()
+#     def describe(self):
+#         desc = super().describe()
 
-        if self.parent._mode is SRXMode.fly:
-            spec = {
-                "external": "FileStore:",
-                "dtype": "array",
-                # TODO do not hard code
-                # TODO shape should match number of channels
-                "shape": (self.parent.settings.num_images.get(), 3, 4096),
-                "source": self.prefix,
-            }
-            return {self.parent._f_key: spec}
-        else:
-            return super().describe()
+#         if self.parent._mode is SRXMode.fly:
+#             spec = {
+#                 "external": "FileStore:",
+#                 "dtype": "array",
+#                 # TODO do not hard code
+#                 # TODO shape should match number of channels
+#                 "shape": (self.parent.settings.num_images.get(), 3, 4096),
+#                 "source": self.prefix,
+#             }
+#             return {self.parent._f_key: spec}
+#         else:
+#             return super().describe()
 
 
 # JL copied Xspress3FileStoreFlyable in 31-xspress3.py
@@ -242,34 +250,34 @@ class CommunityXspress3FileStoreFlyable(CommunityXspress3FileStore):
             return super().describe()
 
 
-class SRXXspressTrigger(XspressTrigger):
-    def trigger(self):
-        if self._staged != Staged.yes:
-            raise RuntimeError("not staged")
+# class SRXXspressTrigger(XspressTrigger):
+#     def trigger(self):
+#         if self._staged != Staged.yes:
+#             raise RuntimeError("not staged")
 
-        self._status = DeviceStatus(self)
-        # the next line causes a ~3s delay in the community IOC
-        self.settings.erase.put(1)
-        self._acquisition_signal.put(1, wait=False)
-        trigger_time = ttime.time()
-        if self._mode is SRXMode.step:
-            # community IOC ophyd xspress3
-            # for channel in self.iterate_channels():
-            #     self.dispatch(channel.name, trigger_time)
-            # quantum IOC ophyd xspress3
-            for sn in self.read_attrs:
-                if sn.startswith("channel") and "." not in sn:
-                    ch = getattr(self, sn)
-                    self.dispatch(ch.name, trigger_time)
-        elif self._mode is SRXMode.fly:
-            self.dispatch(self._f_key, trigger_time)
-        else:
-            raise Exception(f"unexpected mode {self._mode}")
-        self._abs_trigger_count += 1
-        return self._status
+#         self._status = DeviceStatus(self)
+#         # the next line causes a ~3s delay in the community IOC
+#         self.settings.erase.put(1)
+#         self._acquisition_signal.put(1, wait=False)
+#         trigger_time = ttime.time()
+#         if self._mode is SRXMode.step:
+#             # community IOC ophyd xspress3
+#             # for channel in self.iterate_channels():
+#             #     self.dispatch(channel.name, trigger_time)
+#             # quantum IOC ophyd xspress3
+#             for sn in self.read_attrs:
+#                 if sn.startswith("channel") and "." not in sn:
+#                     ch = getattr(self, sn)
+#                     self.dispatch(ch.name, trigger_time)
+#         elif self._mode is SRXMode.fly:
+#             self.dispatch(self._f_key, trigger_time)
+#         else:
+#             raise Exception(f"unexpected mode {self._mode}")
+#         self._abs_trigger_count += 1
+#         return self._status
 
 
-class CommunitySRXXspressTrigger(CommunityXspressTrigger):
+class CommunitySRXXspressTrigger(Xspress3Trigger):
     def trigger(self):
         if self._staged != Staged.yes:
             raise RuntimeError("not staged")
@@ -307,119 +315,136 @@ class SrxXSP3Handler:
             return np.asarray(f[self.XRF_DATA_KEY])
 
 # build a community IOC xspress3 class with 4 channels
+# CommunityXspress3_8Channel = build_xspress3_class(
+#     channel_numbers=(1, 2, 3, 4, 5, 6, 7, 8),
+#     mcaroi_numbers=(1, 2, 3, 4)
+# )
+
+# build a community IOC xspress3 class with 8 channels
 CommunityXspress3_8Channel = build_xspress3_class(
     channel_numbers=(1, 2, 3, 4, 5, 6, 7, 8),
-    mcaroi_numbers=(1, 2, 3, 4)
+    mcaroi_numbers=(1, 2, 3, 4),
+    image_data_key="fluor",
+    xspress3_parent_classes=(Xspress3Detector, Xspress3Trigger),
+    extra_class_members={
+        "hdf5": Cpt(
+            Xspress3HDF5Plugin,
+            "HDF1:",
+            name="hdf5",
+            root_path="/nsls2/data/srx/assets/xspress3",
+            path_template="/nsls2/data/srx/assets/xspress3/%Y/%m/%d",
+        )
+    }
 )
 
-class SrxXspress3Detector(SRXXspressTrigger, Xspress3Detector):
-    # provided by CommunityXspress3_4Channel
-    roi_data = Cpt(PluginBase, "ROIDATA:")
-    erase = Cpt(EpicsSignal, "ERASE")
-    array_counter = Cpt(EpicsSignal, "ArrayCounter_RBV")
+# class SrxXspress3Detector(SRXXspressTrigger, Xspress3Detector):
+#     # provided by CommunityXspress3_4Channel
+#     roi_data = Cpt(PluginBase, "ROIDATA:")
+#     erase = Cpt(EpicsSignal, "ERASE")
+#     array_counter = Cpt(EpicsSignal, "ArrayCounter_RBV")
 
-    # channel attributes are provided by CommunityXspress3_4Channel
-    # Currently only using three channels. Uncomment these to enable more
-    channel1 = Cpt(Xspress3Channel, "C1_", channel_num=1, read_attrs=["rois"])
-    channel2 = Cpt(Xspress3Channel, "C2_", channel_num=2, read_attrs=["rois"])
-    channel3 = Cpt(Xspress3Channel, "C3_", channel_num=3, read_attrs=["rois"])
-    channel4 = Cpt(Xspress3Channel, "C4_", channel_num=4, read_attrs=["rois"])
-    # channels:
-    # channel5 = Cpt(Xspress3Channel, 'C5_', channel_num=5)
-    # channel6 = Cpt(Xspress3Channel, 'C6_', channel_num=6)
-    # channel7 = Cpt(Xspress3Channel, 'C7_', channel_num=7)
-    # channel8 = Cpt(Xspress3Channel, 'C8_', channel_num=8)
+#     # channel attributes are provided by CommunityXspress3_4Channel
+#     # Currently only using three channels. Uncomment these to enable more
+#     channel1 = Cpt(Xspress3Channel, "C1_", channel_num=1, read_attrs=["rois"])
+#     channel2 = Cpt(Xspress3Channel, "C2_", channel_num=2, read_attrs=["rois"])
+#     channel3 = Cpt(Xspress3Channel, "C3_", channel_num=3, read_attrs=["rois"])
+#     channel4 = Cpt(Xspress3Channel, "C4_", channel_num=4, read_attrs=["rois"])
+#     # channels:
+#     # channel5 = Cpt(Xspress3Channel, 'C5_', channel_num=5)
+#     # channel6 = Cpt(Xspress3Channel, 'C6_', channel_num=6)
+#     # channel7 = Cpt(Xspress3Channel, 'C7_', channel_num=7)
+#     # channel8 = Cpt(Xspress3Channel, 'C8_', channel_num=8)
 
-    # replace HDF5:FileCreateDir with HDF1:FileCreateDir
-    create_dir = Cpt(EpicsSignal, "HDF5:FileCreateDir")
+#     # replace HDF5:FileCreateDir with HDF1:FileCreateDir
+#     create_dir = Cpt(EpicsSignal, "HDF5:FileCreateDir")
 
-    hdf5 = Cpt(
-        Xspress3FileStoreFlyable,
-        "HDF5:",
-        read_path_template="/nsls2/data/srx/assets/xspress3/%Y/%m/%d",
-        write_path_template="/nsls2/data/srx/assets/xspress3/%Y/%m/%d",
-        root="/nsls2/data/srx/assets/xspress3",
-    )
+#     hdf5 = Cpt(
+#         Xspress3FileStoreFlyable,
+#         "HDF5:",
+#         read_path_template="/nsls2/data/srx/assets/xspress3/%Y/%m/%d",
+#         write_path_template="/nsls2/data/srx/assets/xspress3/%Y/%m/%d",
+#         root="/nsls2/data/srx/assets/xspress3",
+#     )
 
-    # this is used as a latch to put the xspress3 into 'bulk' mode
-    # for fly scanning.  Do this is a signal (rather than as a local variable
-    # or as a method so we can modify this as part of a plan
-    fly_next = Cpt(Signal, value=False)
+#     # this is used as a latch to put the xspress3 into 'bulk' mode
+#     # for fly scanning.  Do this is a signal (rather than as a local variable
+#     # or as a method so we can modify this as part of a plan
+#     fly_next = Cpt(Signal, value=False)
 
-    def __init__(
-        self,
-        prefix,
-        *,
-        f_key="fluor",
-        configuration_attrs=None,
-        read_attrs=None,
-        **kwargs,
-    ):
-        self._f_key = f_key
-        if configuration_attrs is None:
-            configuration_attrs = [
-                "external_trig",
-                "total_points",
-                "spectra_per_point",
-                "settings",  # replaced settings with cam
-                "rewindable",
-            ]
-        if read_attrs is None:
-            read_attrs = ["channel1", "channel2", "channel3", "channel4", "hdf5"]
-        super().__init__(
-            prefix,
-            configuration_attrs=configuration_attrs,
-            read_attrs=read_attrs,
-            **kwargs,
-        )
-        # this is possiblely one too many places to store this
-        # in the parent class it looks at if the extrenal_trig signal is high
-        self._mode = SRXMode.step
+#     def __init__(
+#         self,
+#         prefix,
+#         *,
+#         f_key="fluor",
+#         configuration_attrs=None,
+#         read_attrs=None,
+#         **kwargs,
+#     ):
+#         self._f_key = f_key
+#         if configuration_attrs is None:
+#             configuration_attrs = [
+#                 "external_trig",
+#                 "total_points",
+#                 "spectra_per_point",
+#                 "settings",  # replaced settings with cam
+#                 "rewindable",
+#             ]
+#         if read_attrs is None:
+#             read_attrs = ["channel1", "channel2", "channel3", "channel4", "hdf5"]
+#         super().__init__(
+#             prefix,
+#             configuration_attrs=configuration_attrs,
+#             read_attrs=read_attrs,
+#             **kwargs,
+#         )
+#         # this is possiblely one too many places to store this
+#         # in the parent class it looks at if the extrenal_trig signal is high
+#         self._mode = SRXMode.step
 
-        # 2020-01-24
-        # Commented out by AMK for using the xs3-server-IOC from TES
-        # self.create_dir.put(-3)
+#         # 2020-01-24
+#         # Commented out by AMK for using the xs3-server-IOC from TES
+#         # self.create_dir.put(-3)
 
-    def stop(self, *, success=False):
-        ret = super().stop()
-        # todo move this into the stop method of the settings object?
-        self.settings.acquire.put(0)
-        self.hdf5.stop(success=success)
-        return ret
+#     def stop(self, *, success=False):
+#         ret = super().stop()
+#         # todo move this into the stop method of the settings object?
+#         self.settings.acquire.put(0)
+#         self.hdf5.stop(success=success)
+#         return ret
 
-    def stage(self):
-        # print("stage!")
-        # Erase what is currently in the system
-        # This prevents a single hot pixel in the upper-left corner of a map
-        # JL replaced xs.erase.put(0) with self.cam.erase.put(0)
-        #    why was xs.erase.put(0) not self.erase.put(0) ?
-        self.erase.put(0)
-        # JL commented out the next line because it caused a significant delay in starting acqusitions
-        #self.cam.erase.put(0)
-        # JL added the next line, it is not pretty
-        # self.previous_file_write_mode_value = self.hdf5.file_write_mode.get()
-        # JL added the next 2 lines
-        #   should use stage_sigs for file_write_mode?
-        # self.hdf5.file_write_mode.put(1)
-        #self.hdf5.auto_save.put(1)  # using stage_sigs for this
-        # do the latching
-        if self.fly_next.get():
-            self.fly_next.put(False)
-            self._mode = SRXMode.fly
-        return super().stage()
+#     def stage(self):
+#         # print("stage!")
+#         # Erase what is currently in the system
+#         # This prevents a single hot pixel in the upper-left corner of a map
+#         # JL replaced xs.erase.put(0) with self.cam.erase.put(0)
+#         #    why was xs.erase.put(0) not self.erase.put(0) ?
+#         self.erase.put(0)
+#         # JL commented out the next line because it caused a significant delay in starting acqusitions
+#         #self.cam.erase.put(0)
+#         # JL added the next line, it is not pretty
+#         # self.previous_file_write_mode_value = self.hdf5.file_write_mode.get()
+#         # JL added the next 2 lines
+#         #   should use stage_sigs for file_write_mode?
+#         # self.hdf5.file_write_mode.put(1)
+#         #self.hdf5.auto_save.put(1)  # using stage_sigs for this
+#         # do the latching
+#         if self.fly_next.get():
+#             self.fly_next.put(False)
+#             self._mode = SRXMode.fly
+#         return super().stage()
 
-    def unstage(self):
-        # print("unstage!")
-        # JL added the next two lines
-        #self.hdf5.auto_save.put(0)
-        # self.hdf5.file_write_mode.put(self.previous_file_write_mode_value)
-        # JL removed the next line
-        self.hdf5.capture.put(0)  # this PV un-sets itself
-        try:
-            ret = super().unstage()
-        finally:
-            self._mode = SRXMode.step
-        return ret
+#     def unstage(self):
+#         # print("unstage!")
+#         # JL added the next two lines
+#         #self.hdf5.auto_save.put(0)
+#         # self.hdf5.file_write_mode.put(self.previous_file_write_mode_value)
+#         # JL removed the next line
+#         self.hdf5.capture.put(0)  # this PV un-sets itself
+#         try:
+#             ret = super().unstage()
+#         finally:
+#             self._mode = SRXMode.step
+#         return ret
 
 
 class CommunitySrxXspress3Detector(CommunitySRXXspressTrigger, CommunityXspress3_8Channel):
@@ -443,13 +468,13 @@ class CommunitySrxXspress3Detector(CommunitySRXXspressTrigger, CommunityXspress3
     # replace HDF5:FileCreateDir with HDF1:FileCreateDir
     create_dir = Cpt(EpicsSignal, "HDF1:FileCreateDir")
 
-    hdf5 = Cpt(
-        CommunityXspress3FileStoreFlyable,
-        "HDF1:",
-        read_path_template="/nsls2/data/srx/assets/xspress3/%Y/%m/%d",
-        write_path_template="/nsls2/data/srx/assets/xspress3/%Y/%m/%d",
-        root="/nsls2/data/srx/assets/xspress3",
-    )
+    # hdf5 = Cpt(
+    #     CommunityXspress3FileStoreFlyable,
+    #     "HDF1:",
+    #     read_path_template="/nsls2/data/srx/assets/xspress3/%Y/%m/%d",
+    #     write_path_template="/nsls2/data/srx/assets/xspress3/%Y/%m/%d",
+    #     root="/nsls2/data/srx/assets/xspress3",
+    # )
 
     # this is used as a latch to put the xspress3 into 'bulk' mode
     # for fly scanning.  Do this is a signal (rather than as a local variable
@@ -610,7 +635,6 @@ class SrxXspress3DetectorIDMonoFly(CommunitySrxXspress3Detector):
             yield item
 
 
-
 try:
     xs_id_mono_fly = SrxXspress3DetectorIDMonoFly("XF:05IDD-ES{Xsp:3}:", name="xs_id_mono_fly")
     # add all channel.channelNN to xs.read_attrs 
@@ -697,13 +721,13 @@ class SrxXspress3Detector2(CommunitySRXXspressTrigger, Xspress3Detector):
 
     create_dir = Cpt(EpicsSignal, "HDF5:FileCreateDir")
 
-    hdf5 = Cpt(
-        CommunityXspress3FileStoreFlyable,  # JL replaced Xspress3FileStoreFlyable with CommunityXspress3FileStoreFlyable
-        "HDF5:",
-        read_path_template="/nsls2/xf05id1/data/2020-2/XS3MINI",
-        write_path_template="/home/xspress3/data/SRX/2020-2",
-        root="/nsls2/xf05id1",
-    )
+    # hdf5 = Cpt(
+    #     CommunityXspress3FileStoreFlyable,  # JL replaced Xspress3FileStoreFlyable with CommunityXspress3FileStoreFlyable
+    #     "HDF5:",
+    #     read_path_template="/nsls2/xf05id1/data/2020-2/XS3MINI",
+    #     write_path_template="/home/xspress3/data/SRX/2020-2",
+    #     root="/nsls2/xf05id1",
+    # )
 
     # this is used as a latch to put the xspress3 into 'bulk' mode
     # for fly scanning.  Do this is a signal (rather than as a local variable
@@ -853,5 +877,7 @@ except Exception as ex:
     xs = None
     print("\nUnexpected error connecting to xs.\n")
     print(ex, end="\n\n")
+
+
 
 


### PR DESCRIPTION
We with @dmgav made the first pass with the community IOC ophyd classes from the `nslsii` package, and it worked with some manual preparation. Need to address the following items:

TODOs:

- [ ] Set up TTL Veto mode and number of points in the external trigger mode.
- [ ] Fix the shapes dynamically:
   ```py
    xs.fluor.shape = (121, 8, 4096)
    xs.fluor.describe()
    Out[2]:
    {'fluor': {'source': 'SIM:fluor',
     'dtype': 'array',
     'shape': (121, 8, 4096),
     'external': 'FILESTORE:',
     'dtype_str': 'uint32',
     'dims': ('bin_count',)}}
    ```
- [ ] Sort out the wrong shape (251, 4, 4096) - looks like it was related to the `xs.fluor.name = "fluor"` change. Without it it worked OK.