### PR TITLE
update Tiled clients to direct traffic to acquisition node

### DIFF
--- a/startup/00-base.py
+++ b/startup/00-base.py
@@ -148,6 +148,7 @@ RE.unsubscribe(0)
 
 # Define tiled catalog
 srx_raw = from_profile("srx", api_key=os.environ["TILED_BLUESKY_WRITING_API_KEY_SRX"])
+srx_raw.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 # c = tiled_reading_client = from_uri(
 #         "https://tiled.nsls2.bnl.gov/api/v1/metadata/srx/raw",
@@ -155,6 +156,7 @@ srx_raw = from_profile("srx", api_key=os.environ["TILED_BLUESKY_WRITING_API_KEY_
 # )
 
 c = tiled_reading_client = from_profile("srx", include_data_sources=True)
+c.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 
 discard_liveplot_data = True


### PR DESCRIPTION
Add item that directs use of Tiled acquisition cluster to be used while acquiring data. Tiled clients from Prefect workflows, Jupyter notebooks, and other sources will be isolated from the acquisition cluster, ensuring data acquisition is not negatively affected by non-acquisition Tiled requests.